### PR TITLE
Changing universal links to custom URI schemes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ This will help you create a client and configure the necessary data.
 **Note:** This SDK requires your client to be registered as a `public_mobile_client`. Please
 email our [support](mailto:schibstedaccount@schibsted.com) to get help with setting that up.
 
-**Note:** Using [Universal Links](https://developer.apple.com/ios/universal-links/) should be preferred for [security reasons](https://tools.ietf.org/html/rfc8252#appendix-B.1).
-To make it work seamlessly, please see the section below.
-OBS: Universal Links should be used where possible. A technical limitation of universal links is that they can only be used on user interaction such as clicks. This means that a combination of Universal Links and custom URI schemes need to be used.  
-
 **Note:** If you have implemented the [Old Schibsted SDK](https://github.com/schibsted/account-sdk-ios) in your app, and want these users to remain logged in, do not forget to add the SessionStorageConfig on instantiating your Client, `Client(configuration:sessionStorageConfig:httpClient:)`.   
     
 ### Installation
@@ -70,11 +66,9 @@ class MyUserDelegate: UserDelegate {
 }
 ```
 
-### Notes when using Universal Links
+### Notes on using custom URI schemes
 
-OBS: Universal Links should be used where possible. A technical limitation of universal links is that they can only be used on user interaction such as clicks. This means that a combination of Universal Links and custom URI schemes need to be used.  
-
-When using Universal Links as redirect URI, the OS handles opening the app associated with the link instead of triggering the `ASWebAuthenticationSession` callback.
+When using custom URI as redirect URI, the OS handles opening the app associated with the link instead of triggering the `ASWebAuthenticationSession` callback.
 It results in the `ASWebAuthenticationSession` view not being closed properly, which instead needs to be done manually:
 
 1. Get a reference to `ASWebAuthenticationSession` and start it:


### PR DESCRIPTION
Updating readme to not mention universal links, as it is not working with the current login flow.