### PR TITLE
1622 Using webSession url for showing accountPages

### DIFF
--- a/Projects/AccountSDKIOSWebExample/ExampleWeb/ContentView.swift
+++ b/Projects/AccountSDKIOSWebExample/ExampleWeb/ContentView.swift
@@ -138,7 +138,7 @@ struct ContentView: View {
                 }.disabled(!userIsLoggedIn)
                 
                 Button(action: {
-                    self.user?.webSessionURL(clientId: "5bcdd51bfba0cc7427315112", redirectURI: "http://zoopermarket.com/safepage") { result in
+                    self.user?.webSessionURL(clientId: "602504e1b41fa31789a95aa7", redirectURI: "http://zoopermarket.com/safepage") { result in
                         switch result {
                         case .success(let sessionUrl):
                             print(sessionUrl)
@@ -151,8 +151,17 @@ struct ContentView: View {
                 }.disabled(!userIsLoggedIn)
 
                 Button(action: {
-                    accountPagesURL = self.clientConfiguration.accountPagesURL
-                    showAccountPages = true
+                    self.user?.webSessionURL(clientId: "602504e1b41fa31789a95aa7", redirectURI: self.clientConfiguration.accountPagesURL.absoluteString) { result in
+                        switch result {
+                        case .success(let sessionUrl):
+                            print(sessionUrl)
+                            accountPagesURL = sessionUrl
+                            showAccountPages = true
+                        case .failure(let error):
+                            print(error)
+                        }
+                    }
+
                 }) {
                     Text("Show account pages")
                 }.disabled(!userIsLoggedIn)


### PR DESCRIPTION
A user that has logged in within 30 min. Should not be prompted to log back in on going to account pages. 

Test procedure:
1. Login 
2. Press account pages button.
3. Do you need to login? (Input password should be ok?)
4. Access account pages. (Success)
5. close account pages
6. wait 30 min
7. open account pages. (You should be prompted to log back in)