### PR TITLE
1548 Keychain App Transfer Old to New sdk

### DIFF
--- a/Sources/AccountSDKIOSWeb/Client/Client+AppTransfer.swift
+++ b/Sources/AccountSDKIOSWeb/Client/Client+AppTransfer.swift
@@ -5,6 +5,7 @@ extension Client {
     public enum AppTransfer {
         case preTransfer(_ clientId: String, _ accessGroup: String?)
         case postTransfer(accessGroup: String?, completion: (Result<Void, Error>) -> Void)
+        case postTransferFromOldSDK(accessGroup: String?, completion: (Result<Void, Error>) -> Void)  /// Only needs to be invoked if the old SDK was used to store login data pre App Transfer.
         case clear
         
         public enum AppTransferError: Error {
@@ -17,6 +18,8 @@ extension Client {
                 try Client.storeOnDevice(clientId: clientId, key: key, accessGroup: accessGroup)
             case .postTransfer(let accessGroup, let completion):
                 Client.loadFromDeviceToKeychain(key: key, accessGroup: accessGroup, completion: completion)
+            case .postTransferFromOldSDK(let accessGroup, let completion):
+                try Client.loadOldSDKDataFromDeviceToKeychain(key: key, accessGroup: accessGroup, completion: completion)
             case .clear:
                 Client.clearStoredUserOnDevice(key: key)
             }
@@ -24,6 +27,7 @@ extension Client {
     }
     
     private static let keyPrefix = "new-sdk-app-transfer-"
+    private static let oldSDKKeyPrefix = "old-sdk-app-transfer-"
 
     private static func storeOnDevice(clientId: String, key: String, accessGroup: String?) throws {
         do {
@@ -61,6 +65,23 @@ extension Client {
             }
         } catch {
             SchibstedAccountLogger.instance.info("Failed from to storeFromDeviceToKeychain: \(error.localizedDescription)")
+            completion(.failure(error))
+        }
+    }
+    
+    private static func loadOldSDKDataFromDeviceToKeychain(key: String, accessGroup: String?, completion: @escaping (Result<Void, Error>) -> Void) throws {
+        guard let tokenData = UserDefaults.standard.object(forKey: Client.oldSDKKeyPrefix + key) as? Data else {
+            completion(.failure(AppTransfer.AppTransferError.UserSessionNotFound))
+            return
+        }
+        
+        do {
+            let kc = LegacyKeychainTokenStorage(accessGroup: accessGroup)
+            try kc.set(legacySDKtokenData: tokenData)
+            Client.clearStoredUserOnDevice(key: key)
+            completion(.success())
+        } catch {
+            SchibstedAccountLogger.instance.info("failed from to storeFromDeviceToKeychain: \(error.localizedDescription)")
             completion(.failure(error))
         }
     }

--- a/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainTokenStorage.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainTokenStorage.swift
@@ -9,6 +9,12 @@ struct LegacyTokenData: Equatable {
 class LegacyKeychainTokenStorage {
     private let service = "swift.keychain.service"
     private let account = "SchibstedID"
+    enum KeychainKey {
+        static let refreshToken = "refresh_token"
+        static let idToken = "id_token"
+        static let loggedInUsers = "logged_in_users"
+        static let userID = "user_id"
+    }
     
     private let keychain: KeychainStorage
 
@@ -43,20 +49,54 @@ class LegacyKeychainTokenStorage {
             return []
         }
         
-        guard let parsed = deserialised["logged_in_users"] as? [String: [String: Any]] else {
+        guard let parsed = deserialised[Self.KeychainKey.loggedInUsers] as? [String: [String: Any]] else {
             SchibstedAccountLogger.instance.error("Failed to parse legacy keychain data")
             return []
         }
         
         let storedTokens: [LegacyTokenData] = parsed.compactMap { (accessToken, data) in
-            guard let refreshToken = data["refresh_token"] as? String,
-                  let idToken = data["id_token"] as? String else {
+            guard let refreshToken = data[Self.KeychainKey.refreshToken] as? String,
+                  let idToken = data[Self.KeychainKey.idToken] as? String else {
                       return nil
                   }
             return LegacyTokenData(accessToken: accessToken, refreshToken: refreshToken, idToken: idToken)
         }
         
         return storedTokens
+    }
+    
+    /**
+     == LegacySDKtokenData  data structure ==
+        {
+        "idToken":{
+            "string":<idToken>
+        },
+        "refreshToken":<refreshToken>,
+        "accessToken":<accessToken
+        "userID":<userID>
+        }
+     */
+    func set(legacySDKtokenData: Data) throws {
+        let json = try JSONSerialization.jsonObject(with: legacySDKtokenData, options: [])
+        guard let dict = json as? [String: Any],
+              let accessToken = dict["accessToken"] as? String,
+              let refreshToken = dict["refreshToken"] as? String,
+              let idTokenDict = dict["idToken"] as? [String: Any],
+              let idToken = idTokenDict["string"] as? String,
+              let userId = dict["userID"] as? String else {
+                  throw KeychainStorageError.storeError
+        }
+        
+        // Build as Legacy Keychain JSON structure
+        var loggedInUsers: [String: [String: String]] = [:]
+        let loggedInUser: [String: String] = [Self.KeychainKey.refreshToken: refreshToken,
+                                              Self.KeychainKey.idToken: idToken,
+                                              Self.KeychainKey.userID: userId]
+        loggedInUsers[accessToken] = loggedInUser
+        let keychainData = [Self.KeychainKey.loggedInUsers: loggedInUsers]
+        
+        let data = try NSKeyedArchiver.archivedData(withRootObject: keychainData, requiringSecureCoding: true)
+        try keychain.setValue(data, forAccount: account)
     }
     
     func remove() {


### PR DESCRIPTION
To test that it works:

1. Login with old SDK.
2. Call function in OLD SDK [storeOnDevice](https://github.com/schibsted/account-sdk-ios/blob/master/Source/Manager/User/User%2Bload.swift#L20) 
3. Logout and make sure keychain is purged.
4. Use the new SDK to invoke [`postTransferFromOldSDK`](https://github.com/schibsted/account-sdk-ios-web/blob/1548-keychain-apptransfer-old-to-new-sdk/Sources/AccountSDKIOSWeb/Client/Client%2BAppTransfer.swift#L8)
5. Use new SDK to [resumeLastLoggedInUser](https://github.com/schibsted/account-sdk-ios-web/blob/master/Sources/AccountSDKIOSWeb/Client/Client.swift#L237)
6. You should be logged in
 