### PR TITLE
1847 Make Schibsted logo bigger & fix brands icon with round border

### DIFF
--- a/Sources/AccountSDKIOSWeb/Simplified Login/Sub Views/FooterView.swift
+++ b/Sources/AccountSDKIOSWeb/Simplified Login/Sub Views/FooterView.swift
@@ -30,7 +30,7 @@ class FooterView: UIStackView {
         
         view.image = image
         view.contentMode = .center
-        view.contentMode = .scaleAspectFit
+        view.contentMode = .scaleAspectFill
         
         return view
     }()
@@ -110,7 +110,7 @@ class FooterView: UIStackView {
     private func getRoundedImageView(name: String) -> UIImageView {
         let view = UIImageView()
         
-        view.layer.cornerRadius = 13
+        view.layer.cornerRadius = 16
         view.clipsToBounds = true
         let image  = UIImage(named: name, in: Bundle.accountSDK(for: FooterView.self), compatibleWith: nil) ?? UIImage()
         view.image = image

--- a/Sources/AccountSDKIOSWeb/Simplified Login/Sub Views/FooterView.swift
+++ b/Sources/AccountSDKIOSWeb/Simplified Login/Sub Views/FooterView.swift
@@ -109,9 +109,12 @@ class FooterView: UIStackView {
     
     private func getRoundedImageView(name: String) -> UIImageView {
         let view = UIImageView()
-        
+        view.layer.masksToBounds = true
+        view.layer.borderWidth = 2
+        view.layer.borderColor = UIColor.white.cgColor
         view.layer.cornerRadius = 16
         view.clipsToBounds = true
+        
         let image  = UIImage(named: name, in: Bundle.accountSDK(for: FooterView.self), compatibleWith: nil) ?? UIImage()
         view.image = image
         


### PR DESCRIPTION
According to the design, the Schibsted logo was too small. Fixed it.
<img width="838" alt="Screenshot 2021-12-02 at 10 07 04" src="https://user-images.githubusercontent.com/91895636/144391924-07b59424-52fe-4ffb-83cd-5924f176fbbf.png">
Now:
<img width="322" alt="Screenshot 2021-12-02 at 13 52 25" src="https://user-images.githubusercontent.com/91895636/144425716-afcbc6a7-54c6-4297-8c8c-aa1a03587936.png">

