### PR TITLE
1926 SimplifiedLogin initials on empty Name

### DIFF
--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/SimplifiedLogin/SimplifiedLoginViewModelTests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/SimplifiedLogin/SimplifiedLoginViewModelTests.swift
@@ -3,29 +3,19 @@ import XCTest
 
 final class SimplifiedLoginViewModelTests: XCTestCase {
     
-    fileprivate struct ImageData: SimplifiedLoginNamedImageData {
-        var env: ClientConfiguration.Environment = .pre
-        var schibstedLogoName: String = "logo_name"
-    }
-    
-    fileprivate struct UserData: SimplifiedLoginViewModelUserData {
-        var userContext = Fixtures.userContext
-        var userProfileResponse = Fixtures.userProfileResponse
-    }
-    
     func testSimplifiedLoginModelCreation() {
         let imageData = ImageData()
         let userData = UserData()
         let localizationModel = SimplifiedLoginLocalizationModel()
 
-        let model = SimplifiedLoginViewModel(imageDataModel: imageData, userDataModel: userData, localizationModel: localizationModel, visibleClientName: "Schibsted")
+        let viewModel = SimplifiedLoginViewModel(imageDataModel: imageData, userDataModel: userData, localizationModel: localizationModel, visibleClientName: "Schibsted")
         
-        XCTAssertEqual(model.clientName, "Schibsted")
-        XCTAssertEqual(model.schibstedLogoName, imageData
+        XCTAssertEqual(viewModel.clientName, "Schibsted")
+        XCTAssertEqual(viewModel.schibstedLogoName, imageData
                         .schibstedLogoName)
-        XCTAssertEqual(model.initials, "JW")
-        XCTAssertEqual(model.iconNames, imageData.iconNames)
-        XCTAssertEqual(model.displayName, userData.userProfileResponse.displayName)
+        XCTAssertEqual(viewModel.initials, "JW")
+        XCTAssertEqual(viewModel.iconNames, imageData.iconNames)
+        XCTAssertEqual(viewModel.displayName, userData.userProfileResponse.displayName)
     }
     
     func testCallingLoginUserActions() {
@@ -33,32 +23,117 @@ final class SimplifiedLoginViewModelTests: XCTestCase {
         let userData = UserData()
         let localizationModel = SimplifiedLoginLocalizationModel()
 
-        let model = SimplifiedLoginViewModel(imageDataModel: imageData, userDataModel: userData, localizationModel: localizationModel, visibleClientName: "Schibsted")
+        let viewModel = SimplifiedLoginViewModel(imageDataModel: imageData, userDataModel: userData, localizationModel: localizationModel, visibleClientName: "Schibsted")
         
         let didCallPrivacyPolicy = self.expectation(description: "Correctly call privacy policy closure")
         let didCallContinueAsUser = self.expectation(description: "Correctly call continue as closure")
         let didCallContinueWithoutLogin = self.expectation(description: "Correctly call continue without login closure")
         let didCallLoginWithDifferentAccount = self.expectation(description: "Correctly call login with different account closure")
 
-        model.onClickedPrivacyPolicy = {
+        viewModel.onClickedPrivacyPolicy = {
             didCallPrivacyPolicy.fulfill()
         }
-        model.onClickedSwitchAccount = {
+        viewModel.onClickedSwitchAccount = {
             didCallLoginWithDifferentAccount.fulfill()
         }
-        model.onClickedContinueAsUser = {
+        viewModel.onClickedContinueAsUser = {
             didCallContinueAsUser.fulfill()
         }
-        model.onClickedContinueWithoutLogin = {
+        viewModel.onClickedContinueWithoutLogin = {
             didCallContinueWithoutLogin.fulfill()
         }
         
-        model.send(action: .clickedClickPrivacyPolicy)
-        model.send(action: .clickedContinueAsUser)
-        model.send(action: .clickedContinueWithoutLogin)
-        model.send(action: .clickedLoginWithDifferentAccount)
+        viewModel.send(action: .clickedClickPrivacyPolicy)
+        viewModel.send(action: .clickedContinueAsUser)
+        viewModel.send(action: .clickedContinueWithoutLogin)
+        viewModel.send(action: .clickedLoginWithDifferentAccount)
         
         waitForExpectations(timeout: 1.0, handler: nil)
     }
+    
+    func testInitials () {
+        let imageData = ImageData()
+        let localizationModel = SimplifiedLoginLocalizationModel()
+        
+        let displayName = "Test Display name"
+        let givenName = "A name"
+        let familyName = "some familyName"
+        let userData = buildUserProfileResponse(givenName: givenName, familyName: familyName, displayName: displayName)
+        
+        let viewModel = SimplifiedLoginViewModel(imageDataModel: imageData,
+                                                 userDataModel: userData,
+                                                 localizationModel: localizationModel,
+                                                 visibleClientName: "Schibsted")
+        
+        XCTAssertEqual(viewModel.initials, "AS", "Initials should come from displayname if givenName and FamilyName is empty")
+    }
+    
+    func testInitials_emptyName () {
+        let imageData = ImageData()
+        let localizationModel = SimplifiedLoginLocalizationModel()
+        
+        let displayName = "Test Display name"
+        let givenName = ""
+        let familyName = ""
+        let userData = buildUserProfileResponse(givenName: givenName, familyName: familyName, displayName: displayName)
+        
+        let viewModel = SimplifiedLoginViewModel(imageDataModel: imageData,
+                                                 userDataModel: userData,
+                                                 localizationModel: localizationModel,
+                                                 visibleClientName: "Schibsted")
+        
+        XCTAssertEqual(viewModel.initials, "T", "Initials should come from givenName and FamilyName if set")
+    }
+    
+    func testInitials_emptyGivenName () {
+        let imageData = ImageData()
+        let localizationModel = SimplifiedLoginLocalizationModel()
+        
+        let displayName = "Test Display name"
+        let givenName = ""
+        let familyName = "Some name"
+        let userData = buildUserProfileResponse(givenName: givenName, familyName: familyName, displayName: displayName)
+        
+        let viewModel = SimplifiedLoginViewModel(imageDataModel: imageData,
+                                                 userDataModel: userData,
+                                                 localizationModel: localizationModel,
+                                                 visibleClientName: "Schibsted")
+        
+        XCTAssertEqual(viewModel.initials, "T", "Initials should come from displayname if givenName is empty")
+    }
+    
+    func testInitials_emptyFamilyName () {
+        let imageData = ImageData()
+        let localizationModel = SimplifiedLoginLocalizationModel()
+        
+        let displayName = "Test Display name"
+        let givenName = "A given name"
+        let familyName = ""
+        let userData = buildUserProfileResponse(givenName: givenName, familyName: familyName, displayName: displayName)
+        
+        let viewModel = SimplifiedLoginViewModel(imageDataModel: imageData,
+                                                 userDataModel: userData,
+                                                 localizationModel: localizationModel,
+                                                 visibleClientName: "Schibsted")
+        
+        XCTAssertEqual(viewModel.initials, "T", "Initials should come from displayname if FamilyName is empty")
+    }
 }
 
+
+fileprivate func buildUserProfileResponse(givenName: String, familyName: String, displayName: String) -> UserData {
+    let userProfileResponse = UserProfileResponse(uuid: "uuid", userId: "12345", status: 0, email: nil, emailVerified: nil, emails: [], phoneNumber: "123456789", phoneNumberVerified: nil, phoneNumbers: [], displayName: "foo", name: Name(givenName: givenName, familyName: familyName, formatted: nil), addresses: [:], gender: nil, birthday: nil, accounts: [:], merchants: [], published: nil, verified: nil, updated: nil, passwordChanged: nil, lastAuthenticated: nil, lastLoggedIn: nil, locale: nil, utcOffset: nil)
+    
+    let context = UserContextFromTokenResponse(identifier: "foo", display_text: displayName, client_name: "bar")
+    return UserData(userContext: context, userProfileResponse: userProfileResponse)
+}
+
+fileprivate struct ImageData: SimplifiedLoginNamedImageData {
+    var env: ClientConfiguration.Environment = .pre
+    var schibstedLogoName: String = "logo_name"
+}
+
+fileprivate struct UserData: SimplifiedLoginViewModelUserData {
+    var userContext = Fixtures.userContext
+    var userProfileResponse = Fixtures.userProfileResponse
+}

--- a/Sources/AccountSDKIOSWeb/Simplified Login/ViewModel/SimplifiedLoginViewModel.swift
+++ b/Sources/AccountSDKIOSWeb/Simplified Login/ViewModel/SimplifiedLoginViewModel.swift
@@ -43,8 +43,15 @@ class SimplifiedLoginViewModel: SimplifiedLoginUserActionable, SimplifiedLoginVi
     var initials: String {
         let firstName  = userData.userProfileResponse.name?.givenName ?? ""
         let lastName = userData.userProfileResponse.name?.familyName ?? ""
-        let initials = "\(firstName.first?.uppercased() ?? "")\(lastName.first?.uppercased() ?? "")"
-        return initials
+        
+        let shouldUseName = !firstName.isEmpty && !lastName.isEmpty
+        if shouldUseName {
+            let initials = "\(firstName.first?.uppercased() ?? "")\(lastName.first?.uppercased() ?? "")"
+            return initials
+        }
+        
+        let displayNameIntital = displayName.first?.uppercased() ?? ""
+        return displayNameIntital
     }
     
     init(imageDataModel: SimplifiedLoginNamedImageData, userDataModel: SimplifiedLoginViewModelUserData, localizationModel: SimplifiedLoginLocalizationModel, visibleClientName: String) {


### PR DESCRIPTION
There are cases where userProfile has no Name data. Logic should then be handled according to https://www.figma.com/file/1AxYNn0zEck0aEGcaHkqYi/Simplified-login-%E2%80%A2-Native-iOS-SDK?node-id=362%3A3782