### PR TITLE
1849 MigratingKeychainCompatStorage clears old keychain on logout.

### DIFF
--- a/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
@@ -88,8 +88,8 @@ class MigratingKeychainCompatStorage: SessionStorage {
     }
     
     func remove(forClientId: String) {
-        // only delegate to new storage; data should have already been removed from legacy storage during migration
         newStorage.remove(forClientId: forClientId)
+        legacyStorage.remove() // data should have already been removed from legacy storage during migration. But could fail.
     }
 }
 


### PR DESCRIPTION
Couldn't reproduce, in conventional way.

Migrating an old SDK user to a new SDK user, consists of a series of steps. Whereas the last step is to clear the old keychain, see [MigratingKeychainCompatStorage](https://github.com/schibsted/account-sdk-ios-web/blob/master/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift#L66-L67)
There is a possibility that the clear-old-keychain step itself fails. This would then mean that the user would be logged in with the new SDK, but also have tokens for the Old SDK available.

Implications that could happen of not clearing the old SDK keychain after a successful migration:
- if a new SDK user chooses to logout. It would only logout the new SDK keychain. 
- So on subsequent invocation to `Client.resumeLastLoggedInUser()`. Old SDK keychain data would exist and the new SDK would then 'migrate' the user again. The experience for the user would be that they are still logged in as usual. 

**Proposed solution:** clears the old keychain on logout as well as the new keychain in the `MigratingKeychainCompatStorage`, alleviating the raised implication.
