### PR TITLE
1993 Cancel action in web login flow, not dismiss SL-view

### DIFF
--- a/Sources/AccountSDKIOSWeb/Simplified Login/SimplifiedLoginUIFactory.swift
+++ b/Sources/AccountSDKIOSWeb/Simplified Login/SimplifiedLoginUIFactory.swift
@@ -24,8 +24,11 @@ struct SimplifiedLoginUIFactory {
         
         let vc = window?.visibleViewController
         let extendedCompletion: LoginResultHandler = { result in
-            DispatchQueue.main.async {
-                vc?.dismiss(animated: true, completion: nil)
+            // Do not dismiss SimplifiedLoginViewController when user cancels web login flow.
+            if Result.failure(LoginError.canceled) != result {
+                DispatchQueue.main.async {
+                    vc?.dismiss(animated: true, completion: nil)
+                }
             }
             completion(result)
         }
@@ -77,8 +80,11 @@ struct SimplifiedLoginUIFactory {
         
         let vc = window?.visibleViewController
         let extendedCompletion: LoginResultHandler = { result in
-            DispatchQueue.main.async {
-                vc?.dismiss(animated: true, completion: nil)
+            // Do not dismiss SimplifiedLoginViewController when user cancels web login flow.
+            if Result.failure(LoginError.canceled) != result {
+                DispatchQueue.main.async {
+                    vc?.dismiss(animated: true, completion: nil)
+                }
             }
             completion(result)
         }


### PR DESCRIPTION
On entering the web login flow for example when a user taps the "switch account" option in the SimplifiedLogin view.
The user has the choice to cancel that web-flow. The existing logic dismissed the web flow and dismissed the SimplifiedLogin native view on pressing cancel.

This PR does not dismiss the Simplified Login native view on cancelling the web login flow.