### PR TITLE
UUI-520: Fix workspace building on Xcode 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,28 @@ on:
 
 env:
   platform: 'iOS Simulator'
-  iOS: '16.2'
-  device: 'iPhone 14'
+  iOS: '17.0.1'
+  device: 'iPhone 15'
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Resolve package dependencies
         run: |
           xcodebuild -resolvePackageDependencies -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj
       - name: Build the SDK
         run: |
           xcodebuild build -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj -scheme AccountSDKIOSWeb -destination "platform=$platform,name=$device,OS=$iOS"
+
       - name: Build for testing
         run: |
           xcodebuild build-for-testing -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj -scheme AccountSDKIOSWebTests -destination "platform=$platform,name=$device,OS=$iOS"
+
       - name: Run unit tests
         run: |
           xcodebuild test-without-building -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj -scheme AccountSDKIOSWebTests -destination "platform=$platform,name=$device,OS=$iOS"

--- a/Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj/project.pbxproj
+++ b/Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj/project.pbxproj
@@ -1468,6 +1468,7 @@
 		OBJ_199 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1499,6 +1500,7 @@
 		OBJ_200 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
- Updated CI to build and test on latest stable version of Xcode - currently 15.0.1
- set `ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO` to fix building `workspace.xcworkspace`, to be tested (hopefully with Hermes) if that breaks anything for brands