### PR TITLE
UUI-582: Add `externalId`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,28 @@ on:
 
 env:
   platform: 'iOS Simulator'
-  iOS: '16.2'
-  device: 'iPhone 14'
+  iOS: '17.0.1'
+  device: 'iPhone 15'
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Resolve package dependencies
         run: |
           xcodebuild -resolvePackageDependencies -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj
       - name: Build the SDK
         run: |
           xcodebuild build -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj -scheme AccountSDKIOSWeb -destination "platform=$platform,name=$device,OS=$iOS"
+
       - name: Build for testing
         run: |
           xcodebuild build-for-testing -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj -scheme AccountSDKIOSWebTests -destination "platform=$platform,name=$device,OS=$iOS"
+
       - name: Run unit tests
         run: |
           xcodebuild test-without-building -project Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj -scheme AccountSDKIOSWebTests -destination "platform=$platform,name=$device,OS=$iOS"

--- a/Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj/project.pbxproj
+++ b/Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj/project.pbxproj
@@ -69,6 +69,16 @@
 		24EB1563267A2354002D9628 /* IdTokenClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EB1557267A2350002D9628 /* IdTokenClaims.swift */; };
 		24EB156F267A2482002D9628 /* IdTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EB156E267A2482002D9628 /* IdTokenValidator.swift */; };
 		595EA45F27BE8BA400492390 /* Synchronized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595EA45E27BE8BA400492390 /* Synchronized.swift */; };
+		91A2A4D22B0E3D800013D5FD /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D12B0E3D800013D5FD /* String+Extensions.swift */; };
+		91A2A4D32B0E3D800013D5FD /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D12B0E3D800013D5FD /* String+Extensions.swift */; };
+		91A2A4D42B0E3D800013D5FD /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D12B0E3D800013D5FD /* String+Extensions.swift */; };
+		91A2A4D52B0E3D800013D5FD /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D12B0E3D800013D5FD /* String+Extensions.swift */; };
+		91A2A4D62B0E3D800013D5FD /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D12B0E3D800013D5FD /* String+Extensions.swift */; };
+		91A2A4D82B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D72B0E3DBC0013D5FD /* Data+Extensions.swift */; };
+		91A2A4D92B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D72B0E3DBC0013D5FD /* Data+Extensions.swift */; };
+		91A2A4DA2B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D72B0E3DBC0013D5FD /* Data+Extensions.swift */; };
+		91A2A4DB2B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D72B0E3DBC0013D5FD /* Data+Extensions.swift */; };
+		91A2A4DC2B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91A2A4D72B0E3DBC0013D5FD /* Data+Extensions.swift */; };
 		A908307B25D287490065D1D9 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = A908307A25D287490065D1D9 /* Logging */; };
 		A93EFCD42630131F008200D1 /* SchibstedAccountAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93EFCD32630131F008200D1 /* SchibstedAccountAPITests.swift */; };
 		A93EFCFE26316CFB008200D1 /* SchibstedAccountAPIResponsesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93EFCFD26316CFB008200D1 /* SchibstedAccountAPIResponsesTests.swift */; };
@@ -215,6 +225,8 @@
 		24EB1557267A2350002D9628 /* IdTokenClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenClaims.swift; sourceTree = "<group>"; };
 		24EB156E267A2482002D9628 /* IdTokenValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdTokenValidator.swift; sourceTree = "<group>"; };
 		595EA45E27BE8BA400492390 /* Synchronized.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Synchronized.swift; sourceTree = "<group>"; };
+		91A2A4D12B0E3D800013D5FD /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		91A2A4D72B0E3DBC0013D5FD /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		A93EFCD32630131F008200D1 /* SchibstedAccountAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchibstedAccountAPITests.swift; sourceTree = "<group>"; };
 		A93EFCFD26316CFB008200D1 /* SchibstedAccountAPIResponsesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchibstedAccountAPIResponsesTests.swift; sourceTree = "<group>"; };
 		A93EFD0526329A25008200D1 /* user-profile-response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "user-profile-response.json"; sourceTree = "<group>"; };
@@ -502,6 +514,7 @@
 		2489C97E26733A0800AA0A4C /* AccountSDKIOSWeb */ = {
 			isa = PBXGroup;
 			children = (
+				91A2A4D02B0E3D530013D5FD /* Extensions */,
 				CEE5181F27CE247F00BD3559 /* Tracking */,
 				CE5225CC2747D69A009E015E /* Resources */,
 				2401AD0A273D009C007C63A6 /* Simplified Login */,
@@ -600,6 +613,15 @@
 				CE998969270EFE0800CB9E95 /* KeychainStorageError.swift */,
 			);
 			path = Errors;
+			sourceTree = "<group>";
+		};
+		91A2A4D02B0E3D530013D5FD /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				91A2A4D12B0E3D800013D5FD /* String+Extensions.swift */,
+				91A2A4D72B0E3DBC0013D5FD /* Data+Extensions.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		A93EFCD2263012FC008200D1 /* API */ = {
@@ -1078,6 +1100,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9941FDA257523C400513EED /* ContentView.swift in Sources */,
+				91A2A4DC2B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */,
+				91A2A4D62B0E3D800013D5FD /* String+Extensions.swift in Sources */,
 				A9941FD8257523C400513EED /* TestHostApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1086,6 +1110,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				91A2A4D82B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */,
+				91A2A4D22B0E3D800013D5FD /* String+Extensions.swift in Sources */,
 				CE699DD42732A8D4009EE30D /* KeychainTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1106,6 +1132,7 @@
 				24AE1A3E26A5972600865A68 /* HTTPURLResponse+Extensions.swift in Sources */,
 				24EB151F267A17A0002D9628 /* LoginStateError.swift in Sources */,
 				2489C9BE26733A0900AA0A4C /* HTTPClient.swift in Sources */,
+				91A2A4D32B0E3D800013D5FD /* String+Extensions.swift in Sources */,
 				24EB14952679DBB9002D9628 /* IdTokenValidationError.swift in Sources */,
 				CE3E9871277C9A7A00B2F403 /* UIWindow+VisibleVC.swift in Sources */,
 				2489C9C226733A0900AA0A4C /* RefreshTokenError.swift in Sources */,
@@ -1129,6 +1156,7 @@
 				2489C9B926733A0900AA0A4C /* URLExtensions.swift in Sources */,
 				2412D14F274BB714001F71A5 /* SimplifiedLoginManager.swift in Sources */,
 				24EB14702679D8C8002D9628 /* MFAType.swift in Sources */,
+				91A2A4D92B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */,
 				595EA45F27BE8BA400492390 /* Synchronized.swift in Sources */,
 				2489C9BC26733A0900AA0A4C /* RetryPolicy.swift in Sources */,
 				2472EA2F275E98C50037433D /* DataModels.swift in Sources */,
@@ -1168,6 +1196,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				91A2A4DA2B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */,
+				91A2A4D42B0E3D800013D5FD /* String+Extensions.swift in Sources */,
 				2459C7A126735C41007A373B /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1181,6 +1211,7 @@
 				CE754A5727103071000F2EA9 /* GeneratedMocks.swift in Sources */,
 				OBJ_245 /* Await.swift in Sources */,
 				OBJ_246 /* ClientTests.swift in Sources */,
+				91A2A4DB2B0E3DBC0013D5FD /* Data+Extensions.swift in Sources */,
 				OBJ_247 /* Fixtures.swift in Sources */,
 				OBJ_249 /* HTTPUtilTests.swift in Sources */,
 				CED92B79272C086200572645 /* XCTestCaseWithMockHTTPClient.swift in Sources */,
@@ -1204,6 +1235,7 @@
 				A93EFCD42630131F008200D1 /* SchibstedAccountAPITests.swift in Sources */,
 				CEDD4B0A290029240011695D /* MockURLSessionProtocol.swift in Sources */,
 				A95F1A2025826AED000D19F5 /* IdTokenClaimsTests.swift in Sources */,
+				91A2A4D52B0E3D800013D5FD /* String+Extensions.swift in Sources */,
 				OBJ_257 /* UserTests.swift in Sources */,
 				A95F1A1F25826AED000D19F5 /* IdTokenValidatorTests.swift in Sources */,
 			);

--- a/Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj/project.pbxproj
+++ b/Projects/AccountSDKIOSWeb/AccountSDKIOSWeb.xcodeproj/project.pbxproj
@@ -1468,6 +1468,7 @@
 		OBJ_199 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1499,6 +1500,7 @@
 		OBJ_200 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Projects/AccountSDKIOSWeb/Resources/user-profile-response.json
+++ b/Projects/AccountSDKIOSWeb/Resources/user-profile-response.json
@@ -61,5 +61,7 @@
     ],
     "updated": "1971-01-01 00:00:00",
     "passwordChanged": "1970-01-01 00:00:00",
-    "status": 1
+    "status": 1,
+    "pairId": "12345",
+    "sdrn": "sdrn:schibsted:user:12345"
 }

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/API/SchibstedAccountAPIResponsesTests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/API/SchibstedAccountAPIResponsesTests.swift
@@ -121,7 +121,9 @@ final class SchibstedAccountAPIResponsesTests: XCTestCase {
             lastAuthenticated: "1970-01-01 00:00:00",
             lastLoggedIn: "1970-01-01 00:00:00",
             locale: "sv_SE",
-            utcOffset: "+02:00"
+            utcOffset: "+02:00",
+            pairId: "12345",
+            sdrn: "sdrn:schibsted:user:12345"
         )
         
         let parsed = try! JSONDecoder().decode(UserProfileResponse.self, from: jsonString.data(using: .utf8)!)

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/ClientTests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/ClientTests.swift
@@ -376,6 +376,21 @@ final class ClientTests: XCTestCase {
         }
         verify(mockSessionStorage, times(2)).store(any(), accessGroup: any(), completion: any())
     }
+    
+    func testGetExternalId() {
+        let client = Client(configuration: Fixtures.clientConfig,
+                            sessionStorage: MockSessionStorage(),
+                            stateStorage: StateStorage(storage: MockStorage()))
+        // value generated via : https://emn178.github.io/online-tools/sha256.html
+        let mockedHash = "e0b2b31df36848059b44ac0ee6784607b003a3688ac6bbdb196d8465bbc8b281"
+        let externalId = client.getExternalId(pairId: "pairId", externalParty: "externalParty", suffix: "optionalSuffix")
+        XCTAssertEqual(externalId, mockedHash)
+        
+        // value generated via : https://emn178.github.io/online-tools/sha256.html
+        let mockedHashWithoutSuffix = "386eb5f9c3e56843ff83e43fa3d69fc4c2b2072f8e8036332baefb04e96f28b9"
+        let externalIdWithoutSuffix = client.getExternalId(pairId: "pairId", externalParty: "externalParty")
+        XCTAssertEqual(externalIdWithoutSuffix, mockedHashWithoutSuffix)
+    }
 }
 
 fileprivate extension Client {

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Fixtures.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Fixtures.swift
@@ -14,7 +14,7 @@ struct Fixtures {
     static let jwsUtil = JWSUtil()
     static let schibstedAccountAPI = SchibstedAccountAPI(baseURL: Fixtures.clientConfig.serverURL, sessionServiceURL: Fixtures.clientConfig.sessionServiceURL)
     
-    static let userProfileResponse = UserProfileResponse(uuid: "uuid", userId: "12345", status: 0, email: nil, emailVerified: nil, emails: [], phoneNumber: "123456789", phoneNumberVerified: nil, phoneNumbers: [], displayName: "foo bar", name: Name(givenName: "John", familyName: "White", formatted: nil), addresses: [:], gender: nil, birthday: nil, accounts: [:], merchants: [], published: nil, verified: nil, updated: nil, passwordChanged: nil, lastAuthenticated: nil, lastLoggedIn: nil, locale: nil, utcOffset: nil)
+    static let userProfileResponse = UserProfileResponse(uuid: "uuid", userId: "12345", status: 0, email: nil, emailVerified: nil, emails: [], phoneNumber: "123456789", phoneNumberVerified: nil, phoneNumbers: [], displayName: "foo bar", name: Name(givenName: "John", familyName: "White", formatted: nil), addresses: [:], gender: nil, birthday: nil, accounts: [:], merchants: [], published: nil, verified: nil, updated: nil, passwordChanged: nil, lastAuthenticated: nil, lastLoggedIn: nil, locale: nil, utcOffset: nil, pairId: nil, sdrn: nil)
     static let userContext = UserContextFromTokenResponse(identifier: "foo", displayText: "foo bar", clientName: "bar")
 }
 

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/SimplifiedLogin/SimplifiedLoginViewModelTests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/SimplifiedLogin/SimplifiedLoginViewModelTests.swift
@@ -122,7 +122,7 @@ final class SimplifiedLoginViewModelTests: XCTestCase {
 
 
 fileprivate func buildUserProfileResponse(givenName: String, familyName: String, displayName: String) -> UserData {
-    let userProfileResponse = UserProfileResponse(uuid: "uuid", userId: "12345", status: 0, email: nil, emailVerified: nil, emails: [], phoneNumber: "123456789", phoneNumberVerified: nil, phoneNumbers: [], displayName: "foo", name: Name(givenName: givenName, familyName: familyName, formatted: nil), addresses: [:], gender: nil, birthday: nil, accounts: [:], merchants: [], published: nil, verified: nil, updated: nil, passwordChanged: nil, lastAuthenticated: nil, lastLoggedIn: nil, locale: nil, utcOffset: nil)
+    let userProfileResponse = UserProfileResponse(uuid: "uuid", userId: "12345", status: 0, email: nil, emailVerified: nil, emails: [], phoneNumber: "123456789", phoneNumberVerified: nil, phoneNumbers: [], displayName: "foo", name: Name(givenName: givenName, familyName: familyName, formatted: nil), addresses: [:], gender: nil, birthday: nil, accounts: [:], merchants: [], published: nil, verified: nil, updated: nil, passwordChanged: nil, lastAuthenticated: nil, lastLoggedIn: nil, locale: nil, utcOffset: nil, pairId: nil, sdrn: nil)
     
     let context = UserContextFromTokenResponse(identifier: "foo", displayText: displayName, clientName: "bar")
     return UserData(userContext: context, userProfileResponse: userProfileResponse)

--- a/Projects/AccountSDKIOSWebExample/ExampleWeb/ExampleWebApp.swift
+++ b/Projects/AccountSDKIOSWebExample/ExampleWeb/ExampleWebApp.swift
@@ -8,10 +8,11 @@ import AccountSDKIOSWeb
 
 @main
 struct ExampleWebApp: App {
-    static let client: Client =  Client(configuration: ExampleWebApp.clientConfiguration, appIdentifierPrefix: nil) //provide appIdentifierPrefix in order to enable Simplified Login feature
-    static let clientConfiguration: ClientConfiguration = ClientConfiguration(environment: .pre,
-                                                                              clientId: "602504e1b41fa31789a95aa7",
-                                                                              redirectURI: URL(string: "com.sdk-example.pre.602504e1b41fa31789a95aa7:/login")!)
+    static let client = Client(configuration: ExampleWebApp.clientConfiguration,
+                               appIdentifierPrefix: nil) //provide appIdentifierPrefix in order to enable Simplified Login feature
+    static let clientConfiguration = ClientConfiguration(environment: .pre,
+                                                         clientId: "602504e1b41fa31789a95aa7",
+                                                         redirectURI: URL(string: "com.sdk-example.pre.602504e1b41fa31789a95aa7:/login")!)
     
 
     var body: some Scene {

--- a/Projects/AccountSDKIOSWebExample/ExampleWeb/Info.plist
+++ b/Projects/AccountSDKIOSWebExample/ExampleWeb/Info.plist
@@ -39,6 +39,8 @@
 	<dict>
 		<key>NSAllowsArbitraryLoadsInWebContent</key>
 		<true/>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>id.localhost</key>

--- a/Sources/AccountSDKIOSWeb/Client/Client.swift
+++ b/Sources/AccountSDKIOSWeb/Client/Client.swift
@@ -390,6 +390,19 @@ extension Client {
         }
     }
 
+    /**
+     Gets an `externalId` identifiying user for a particular brand.
+     
+     - parameter pairId: New identifier returned from our back-end.
+     - parameter externalParty: Name of a 3rd-party integration
+     - parameter suffix: Optional if further categorisation is needed
+     */
+
+    public func getExternalId(pairId: String, externalParty: String, suffix: String = "") -> String? {
+        let stringToHash = suffix.isEmpty ? [pairId, externalParty] : [pairId, externalParty, suffix]
+        return stringToHash.joined(separator: ":").sha256Hexdigest()
+    }
+
     /// Client description containing clientId value.
     public var description: String {
         return "Client(\(configuration.clientId))"

--- a/Sources/AccountSDKIOSWeb/Extensions/Data+Extensions.swift
+++ b/Sources/AccountSDKIOSWeb/Extensions/Data+Extensions.swift
@@ -1,0 +1,32 @@
+//
+// Copyright © 2023 Schibsted.
+// Licensed under the terms of the MIT license. See LICENSE in the project root.
+//
+
+import Foundation
+import CommonCrypto
+
+extension Data {
+    public func sha256Hexdigest() -> String {
+        return hexStringFromData(input: sha256Digest(input: self as NSData))
+    }
+    
+    private func sha256Digest(input: NSData) -> NSData {
+        let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
+        var hash = [UInt8](repeating: 0, count: digestLength)
+        CC_SHA256(input.bytes, UInt32(input.length), &hash)
+        return NSData(bytes: hash, length: digestLength)
+    }
+    
+    func hexStringFromData(input: NSData) -> String {
+        var bytes = [UInt8](repeating: 0, count: input.length)
+        input.getBytes(&bytes, length: input.length)
+        
+        var hexString = ""
+        for byte in bytes {
+            hexString += String(format:"%02x", UInt8(byte))
+        }
+        
+        return hexString
+    }
+}

--- a/Sources/AccountSDKIOSWeb/Extensions/String+Extensions.swift
+++ b/Sources/AccountSDKIOSWeb/Extensions/String+Extensions.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2023 Schibsted.
+// Licensed under the terms of the MIT license. See LICENSE in the project root.
+//
+
+import Foundation
+extension String {
+    func sha256Hexdigest() -> String? {
+        guard let stringData = data(using: String.Encoding.utf8) else {
+            return nil
+        }
+        return stringData.sha256Hexdigest()
+    }
+}

--- a/Sources/AccountSDKIOSWeb/Lib/API/SchibstedAccountAPIResponses.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/API/SchibstedAccountAPIResponses.swift
@@ -30,6 +30,8 @@ public struct UserProfileResponse: Codable, Equatable {
     public var lastLoggedIn: String?
     public var locale: String?
     public var utcOffset: String?
+    public var pairId: String?
+    public var sdrn: String?
 
     public var emailVerifiedDate: String? {
         return emailVerified?.value
@@ -70,7 +72,9 @@ public struct UserProfileResponse: Codable, Equatable {
         lastAuthenticated: String? = nil,
         lastLoggedIn: String? = nil,
         locale: String? = nil,
-        utcOffset: String? = nil
+        utcOffset: String? = nil,
+        pairId: String? = nil,
+        sdrn: String? = nil
     ) {
         self.uuid = uuid
         self.userId = userId
@@ -96,6 +100,8 @@ public struct UserProfileResponse: Codable, Equatable {
         self.lastLoggedIn = lastLoggedIn
         self.locale = locale
         self.utcOffset = utcOffset
+        self.pairId = pairId
+        self.sdrn = sdrn
     }
 
     public init(from decoder: Decoder) throws {
@@ -122,6 +128,8 @@ public struct UserProfileResponse: Codable, Equatable {
         self.lastLoggedIn = try? keyedContainer.decode(String.self, forKey: .lastLoggedIn)
         self.locale = try? keyedContainer.decode(String.self, forKey: .locale)
         self.utcOffset = try? keyedContainer.decode(String.self, forKey: .utcOffset)
+        self.pairId = try? keyedContainer.decode(String.self, forKey: .pairId)
+        self.sdrn = try? keyedContainer.decode(String.self, forKey: .sdrn)
 
         // Backend service could return empty dictionary as an array.
         if let addresses = try? keyedContainer.decodeIfPresent([String: Address].self, forKey: .addresses) {


### PR DESCRIPTION
[UUI-582](https://schibstedio.atlassian.net/browse/UUI-582) :
- Add `pairId` & `sdrn` properties to `UserProfileResponse`
- Add `Client.getExternalId(pairId:externalParty:suffix:)` method
- Add & fix respective unit tests