### PR TITLE
4.2.1: Hotfix: Add Privacy Manifest to CocoaPods

### DIFF
--- a/AccountSDKIOSWeb.podspec
+++ b/AccountSDKIOSWeb.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/schibsted/account-sdk-ios-web.git', :tag => s.version.to_s }
   s.ios.deployment_target = '12.0'
   s.swift_version = '5.0'
-  s.source_files = 'Sources/AccountSDKIOSWeb/**/*.{h,m,swift}'
+  s.source_files = 'Sources/AccountSDKIOSWeb/**/*.{h,m,swift}', 'PrivacyInfo.xcprivacy'
   s.resource_bundles = {'AccountSDKIOSWeb' => 'Sources/AccountSDKIOSWeb/Resources/**/*.{xcassets,ttf,strings}'}
   s.dependency 'JOSESwift', '~> 2.4.0'
   s.dependency 'Logging', '~> 1.4.0'

--- a/AccountSDKIOSWeb.podspec
+++ b/AccountSDKIOSWeb.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AccountSDKIOSWeb'
-  s.version          = '4.2.0'
+  s.version          = '4.2.1'
   s.summary          = 'New implementation of the Schibsted account iOS SDK using the web flows via ASWebAuthenticationSession.'
   s.homepage         = 'https://schibsted.github.io/account-sdk-ios-web/'
   s.license          = { :type => "MIT" }

--- a/Sources/AccountSDKIOSWeb/Lib/Version.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/Version.swift
@@ -3,4 +3,4 @@
 // Licensed under the terms of the MIT license. See LICENSE in the project root.
 //
 
-public let sdkVersion = "4.2.0"
+public let sdkVersion = "4.2.1"


### PR DESCRIPTION
Add missing `PrivacyInfo.xcprivacy` file to CocoaPods source files